### PR TITLE
Fix formatting to be Markdown-compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Attributes
 Usage
 =====
 example for a bridge with pre-up and pre-down script :
+
     network_interfaces "br-test" do
       target "172.16.88.2"
       mask "255.255.255.0"


### PR DESCRIPTION
Just a tini tiny patch to render the example correctly on Github (and probably elsewhere)
