### PR TITLE
fix interfaces.d perms

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -76,6 +76,6 @@ end
 directory "/etc/network/interfaces.d" do
 	owner "root"
 	group "root"
-	mode "0644"
+	mode "0755"
 	action :create
 end


### PR DESCRIPTION
Default debian/ubuntu permissions on /etc/network/interfaces.d is 0755.

Signed-off-by: Vasiliy Tolstov v.tolstov@selfip.ru
